### PR TITLE
Fix manpage install directory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,6 @@ clean:
 
 install: endian
 	mkdir -p ${STAGEDIR}${PREFIX}/bin \
-		${STAGEDIR}${PREFIX}/man/man1
+		${STAGEDIR}${PREFIX}/share/man/man1
 	install -c -m 0755 endian ${STAGEDIR}${PREFIX}/bin
-	install -c -m 0644 endian.1 ${STAGEDIR}${PREFIX}/man/man1
+	install -c -m 0644 endian.1 ${STAGEDIR}${PREFIX}/share/man/man1


### PR DESCRIPTION
Change from $PREFIX/man to $PREFIX/share/man per [FHS](https://refspecs.linuxfoundation.org/fhs.shtml).